### PR TITLE
file parameter added to converted Media value

### DIFF
--- a/lib/src/media_picker.dart
+++ b/lib/src/media_picker.dart
@@ -208,6 +208,7 @@ void openCamera({
       creationTime: DateTime.now(),
       mediaByte: await pickedFile.readAsBytes(),
       title: 'capturedImage',
+      file: File(pickedFile.path),
     );
 
     onCapture(converted);


### PR DESCRIPTION
Hi! I don't know what's the idea behind providing it to user as a Media object, but I used to work with files through their path attribute and I believe a lot of people also do it like this.

So I've added this temp file to a Media parameter for users being able to use file.path arguments.